### PR TITLE
Remove redundant build flags

### DIFF
--- a/nl.openoffice.bluefish.json
+++ b/nl.openoffice.bluefish.json
@@ -18,10 +18,6 @@
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g"
-    },
     "cleanup": ["/include", "/lib/pkgconfig",
                 "/share/pkgconfig", "/share/aclocal",
                 "/man", "/share/man", "*.la", "*.a",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.