### PR TITLE
Bump runtime & update to the latest release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/appdata_release_oars.patch
+++ b/appdata_release_oars.patch
@@ -1,0 +1,12 @@
+--- a/desktop-data/bluefish.appdata.xml.in	2017-05-06 19:55:42.000000000 +0200
++++ b/desktop-data/bluefish.appdata.xml.in	2020-01-26 12:46:58.209705491 +0100
+@@ -33,4 +33,9 @@
+ <kudo>HiDpiIcon</kudo>
+ <kudo>ModernToolkit</kudo>
+ </kudos>
++<content_rating type="oars-1.0" />
++<releases>
++	<release version="2.2.11" date="2017-01-27" />
++	<release version="2.2.10" date="2020-01-24" />
++</releases>
+ </application>

--- a/nl.openoffice.bluefish.json
+++ b/nl.openoffice.bluefish.json
@@ -1,7 +1,7 @@
 {
     "app-id": "nl.openoffice.bluefish",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.30",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "bluefish",
     "rename-icon": "bluefish",
@@ -24,13 +24,14 @@
                 "/share/info", "/share/doc"
     ],
     "modules": [
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "bluefish",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.bennewitz.com/bluefish/stable/source/bluefish-2.2.10.tar.gz",
-                    "sha256": "040746d8bfd9373e271d07a9699d648a02c77095d6ee5f313de72e7ab48284cb"
+                    "url": "https://www.bennewitz.com/bluefish/stable/source/bluefish-2.2.11.tar.gz",
+                    "sha256": "5d4c26365880debe7872c2139a755ee4e45ad74c7aca17c955423282d171f328"
                 }
             ]
         }

--- a/nl.openoffice.bluefish.json
+++ b/nl.openoffice.bluefish.json
@@ -12,11 +12,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--share=network",
-        "--filesystem=home",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--filesystem=home"
     ],
     "cleanup": ["/include", "/lib/pkgconfig",
                 "/share/pkgconfig", "/share/aclocal",
@@ -32,6 +28,10 @@
                     "type": "archive",
                     "url": "https://www.bennewitz.com/bluefish/stable/source/bluefish-2.2.11.tar.gz",
                     "sha256": "5d4c26365880debe7872c2139a755ee4e45ad74c7aca17c955423282d171f328"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata_release_oars.patch"
                 }
             ]
         }


### PR DESCRIPTION
There's nothing to migration post dconf hole removal. The app doesn't seem to use gsettings 