### PR TITLE
Update nl.openoffice.bluefish.json to use fallback-x11

### DIFF
--- a/nl.openoffice.bluefish.json
+++ b/nl.openoffice.bluefish.json
@@ -9,7 +9,7 @@
 	"rename-desktop-file": "bluefish.desktop",
 	"finish-args": [
 		"--share=ipc",
-		"--socket=x11",
+		"--socket=fallback-x11",
 		"--socket=wayland",
 		"--share=network",
 		"--filesystem=host"


### PR DESCRIPTION
to avoid the legacy windowing error on flathub